### PR TITLE
fix use print instead of secho in debug cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(timing VERSION 7.11.1)
+project(timing VERSION 7.12.0)
 
 find_package(daq-cmake REQUIRED)
 

--- a/python/timing/cli/debug.py
+++ b/python/timing/cli/debug.py
@@ -692,7 +692,7 @@ def reset_pll(obj, clocksource):
     if clocksource is None:
         lClockSource = toolbox.get_default_clock_source(
             lDesignType, lBoardType)
-        print(f"Default clock config selected for {kDesignNameMap[lDesignType]} on {kBoardNameMap[lBoardType]} is: {lClockSource}", fg='yellow')
+        secho(f"Default clock config selected for {kDesignNameMap[lDesignType]} on {kBoardNameMap[lBoardType]} is: {lClockSource}", fg='yellow')
     else:
         lClockSource=ClockSource.__members__[clocksource]
 


### PR DESCRIPTION
# Description

use of `print`, instead of `secho` causes error in debug cli. only affects timing python cli

