### PR TITLE
Disable timestamp broadcast before synctime

### DIFF
--- a/src/MasterNode.cpp
+++ b/src/MasterNode.cpp
@@ -299,6 +299,9 @@ MasterNode::apply_endpoint_delay(uint32_t address,      // NOLINT(build/unsigned
 void
 MasterNode::sync_timestamp(TimestampSource source) const // NOLINT(build/unsigned)
 {
+  disable_timestamp_broadcast();
+  TLOG() << "Timestamp broadcast disabled";
+
   set_timestamp(source);
 
   enable_timestamp_broadcast();


### PR DESCRIPTION
# Description

Fix timestamp broadcasting while syncing time, fixes #146.

## Type of change

Bug-fix

## Testing checklist

Tested running ```mst synctime``` and ```mst status``` on GIB and MIB devices, and confirm that the number of sent timestamps has not incremented by more than 10. Previously saw the number increment by about 4,000 for the MIB, and some millions for the GIB.
Also tested after full ```io reset``` on the GIB.

